### PR TITLE
Exclude the podspec from linguist analysis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+SerializedSwift.podspec linguist-vendored


### PR DESCRIPTION
Exclude `/SerializedSwift.podspec` from linguist analysis as it is causing the language statistics to be skewed.