### PR TITLE
StrictSerializedTransformable - SerializedTransformable that doesn't result in Optional types

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,27 @@ var key: String?
  } 
 ```
 
+### `StrictSerializedTransformable`
+- Like `SerializedTransformable` but for non-optional types
+
+```swift
+ class IntToStringTransformer: StrictTransformable {
+    static func transformFromJSON(value: Int) -> String {
+        return String(value)
+    }
+    
+    static func transformToJSON(value: String) -> Int {
+        return Int(value) ?? 0
+    }
+ }
+
+ // Usage of `StrictSerializedTransformable`
+ struct User: Serializable {
+     @StrictSerializedTransformable<IntToStringTransformer>
+     var id: String
+ } 
+```
+
 ### Contribute
 
 This is only a tip of the iceberg of what can one achieve using Property Wrappers and how we can improve Decoding and Encoding JSON in Swift. Feel free to colaborate. 

--- a/Sources/SerializedSwift/StrictSerializedTransformable.swift
+++ b/Sources/SerializedSwift/StrictSerializedTransformable.swift
@@ -1,0 +1,61 @@
+//
+//  StrictSerializedTransformable.swift
+//  
+//
+//  Created by Dejan Skledar on 2022-03-19.
+//
+
+import Foundation
+
+@propertyWrapper
+///
+/// Transformable Serialized Property Wrapper for properties that are transformed with the T: Transformable class.
+///
+public final class StrictSerializedTransformable<T: StrictTransformable> {
+    let key: String?
+    let alternateKey: String?
+    public var wrappedValue: T.To
+    
+    public init(_ key: String? = nil, alternateKey: String? = nil, default value: T.To) {
+        self.key = key
+        self.alternateKey = alternateKey
+        self.wrappedValue = value
+    }
+}
+
+// Encodable support
+extension StrictSerializedTransformable: EncodableProperty where T.From: Encodable {
+    
+    /// Property encoding using the Transformable object - custom transformation
+    /// - Parameters:
+    ///   - container: The default container
+    ///   - propertyName: The Property Name to be used, if key is not present
+    /// - Throws: Throws JSON encoding errorj
+    public func encodeValue(from container: inout EncodeContainer, propertyName: String) throws {
+        let codingKey = SerializedCodingKeys(key: key ?? propertyName)
+        // Encoding the transformed value to JSON value object
+        try container.encode(T.transformToJSON(value: wrappedValue), forKey: codingKey)
+    }
+}
+
+// Decodable support
+extension StrictSerializedTransformable: DecodableProperty where T.From: Decodable {
+    
+    /// Property decoding using the Transformable object. Firstly the JSON object is decoded as per T.From type, then it is transformed to the T.To type
+    /// using the `transformFromJSON` method.
+    /// - Parameters:
+    ///   - container: The decoding container
+    ///   - propertyName: The property name of the Wrapped property. Used if no key (or nil) is present
+    /// - Throws: Doesnt throws anything; Sets the wrappedValue to nil instead (possible crash for non-optionals if no default value was set)
+    public func decodeValue(from container: DecodeContainer, propertyName: String) throws {
+        let codingKey = SerializedCodingKeys(key: key ?? propertyName)
+        
+        if let value = try? container.decodeIfPresent(T.From.self, forKey: codingKey) {
+            self.wrappedValue = T.transformFromJSON(value: value)
+        } else if let altKey = alternateKey {
+            let altCodingKey = SerializedCodingKeys(key: altKey)
+            let value = try? container.decodeIfPresent(T.From.self, forKey: altCodingKey)
+            self.wrappedValue = T.transformFromJSON(value: value)
+        }
+    }
+}

--- a/Sources/SerializedSwift/StrictSerializedTransformable.swift
+++ b/Sources/SerializedSwift/StrictSerializedTransformable.swift
@@ -54,8 +54,9 @@ extension StrictSerializedTransformable: DecodableProperty where T.From: Decodab
             self.wrappedValue = T.transformFromJSON(value: value)
         } else if let altKey = alternateKey {
             let altCodingKey = SerializedCodingKeys(key: altKey)
-            let value = try? container.decodeIfPresent(T.From.self, forKey: altCodingKey)
-            self.wrappedValue = T.transformFromJSON(value: value)
+            if let value = try? container.decodeIfPresent(T.From.self, forKey: altCodingKey) {
+                self.wrappedValue = T.transformFromJSON(value: value)
+            }
         }
     }
 }

--- a/Sources/SerializedSwift/StrictTransformable.swift
+++ b/Sources/SerializedSwift/StrictTransformable.swift
@@ -1,0 +1,26 @@
+//
+//  StrictTransformable.swift
+//  
+//
+//  Created by Leah Lundqvist on 2022-03-19.
+//
+
+import Foundation
+
+public typealias StrictTransformable = StrictTransformableFromJSON & StrictTransformableToJSON
+
+/// StrictTransformableFromJSON protocol for JSON Decoding
+public protocol StrictTransformableFromJSON {
+    associatedtype From: Any
+    associatedtype To: Any
+    
+    static func transformFromJSON(value: From) -> To
+}
+
+// StrictTransformableToJSON for JSON Encoding
+public protocol StrictTransformableToJSON {
+    associatedtype From: Any
+    associatedtype To: Any
+    
+    static func transformToJSON(value: To) -> From
+}


### PR DESCRIPTION
This is probably far from the best way to do something like this, may even be possible in the original package with the methods provided, but I couldn't find a way to do it. Just thought i'd share this as a PR in case anyone finds it useful and wants to refine the concept to be merged into the main branch. If not, feel free to close c:

### Example of `StrictSerializedTransformable`
 - Like `SerializedTransformable` but for non-optional types

 ```swift
  class IntToStringTransformer: StrictTransformable {
     static func transformFromJSON(value: Int) -> String {
         return String(value)
     }
     
     static func transformToJSON(value: String) -> Int {
         return Int(value) ?? 0
     }
  }
  // Usage of `StrictSerializedTransformable`
  struct User: Serializable {
      @StrictSerializedTransformable<IntToStringTransformer>
      var id: String
  } 
 ```

